### PR TITLE
Improve Poctify dashboard and routing

### DIFF
--- a/poctify-codeshare/README.md
+++ b/poctify-codeshare/README.md
@@ -1,0 +1,22 @@
+# POCTIFY CodeShare Detector
+
+This project is a frontend-only React application to analyse POCT device logs.
+It detects potential operator misuse and provides charts and summaries.
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+Visit `http://localhost:5173` to view the app. Upload a CSV or XLSX file
+matching the template in `public/template.csv`.
+
+## Build & Deploy
+
+```bash
+npm run build
+```
+
+Deploy the contents of `dist/` to Netlify or any static host.

--- a/poctify-codeshare/index.html
+++ b/poctify-codeshare/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>POCTIFY CodeShare Detector</title>
+</head>
+<body class="bg-poctifyNavy text-white">
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+</html>

--- a/poctify-codeshare/package.json
+++ b/poctify-codeshare/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "poctify-codeshare",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "xlsx": "^0.18.5",
+    "dayjs": "^1.11.10",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0",
+    "react-router-dom": "^6.22.0",
+    "papaparse": "^5.4.1",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1",
+    "react-icons": "^4.10.1"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.0.0",
+    "postcss": "^8.0.0",
+    "autoprefixer": "^10.0.0"
+  }
+}

--- a/poctify-codeshare/postcss.config.js
+++ b/poctify-codeshare/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/poctify-codeshare/public/template.csv
+++ b/poctify-codeshare/public/template.csv
@@ -1,0 +1,5 @@
+operator_id,timestamp,location,device
+abc123,01/07/2025 08:35,ED Bay 1,Glucometer 7
+abc123,01/07/2025 08:45,ED Bay 1,Glucometer 7
+abc123,01/07/2025 08:55,ED Bay 2,Glucometer 1
+xyz789,01/07/2025 09:00,ED Bay 2,Glucometer 1

--- a/poctify-codeshare/src/App.jsx
+++ b/poctify-codeshare/src/App.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import Navbar from './components/Navbar';
+import Footer from './components/Footer';
+import Home from './pages/Home';
+import Dashboard from './pages/Dashboard';
+
+export default function App() {
+  return (
+    <Router>
+      <div className="flex flex-col min-h-screen bg-poctifyNavy text-white">
+        <Navbar />
+        <div className="flex-grow">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+          </Routes>
+        </div>
+        <Footer />
+      </div>
+    </Router>
+  );
+}

--- a/poctify-codeshare/src/assets/logo.svg
+++ b/poctify-codeshare/src/assets/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#1E40AF" />
+  <text x="50" y="55" text-anchor="middle" font-size="45" fill="white">P</text>
+</svg>

--- a/poctify-codeshare/src/components/ChartsPanel.jsx
+++ b/poctify-codeshare/src/components/ChartsPanel.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Bar, Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend
+);
+
+export default function ChartsPanel({ anomalies }) {
+  const top = [...anomalies]
+    .sort((a, b) => b.totalScore - a.totalScore)
+    .slice(0, 10);
+
+  const barData = {
+    labels: top.map(a => a.operator_id),
+    datasets: [{ label: 'Total Score', data: top.map(a => a.totalScore), backgroundColor: '#1E40AF' }],
+  };
+
+  const hourly = Array(24).fill(0);
+  anomalies.forEach(a => {
+    if (a.hourlyCounts) {
+      Object.entries(a.hourlyCounts).forEach(([h, c]) => {
+        hourly[h] += c;
+      });
+    }
+  });
+
+  const lineData = {
+    labels: hourly.map((_, i) => i),
+    datasets: [{ label: 'Tests', data: hourly, borderColor: '#1E40AF' }],
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="h-64 w-full bg-white p-2 rounded shadow-md">
+        <Bar data={barData} options={{ plugins: { legend: { display: false } } }} />
+      </div>
+      <div className="h-64 w-full bg-white p-2 rounded shadow-md">
+        <Line data={lineData} options={{ plugins: { legend: { display: false } } }} />
+      </div>
+    </div>
+  );
+}

--- a/poctify-codeshare/src/components/Footer.jsx
+++ b/poctify-codeshare/src/components/Footer.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <footer className="bg-poctifyBlue text-white text-center p-4 mt-8">
+      © POCTIFY Ltd. All rights reserved.
+    </footer>
+  );
+}

--- a/poctify-codeshare/src/components/Navbar.jsx
+++ b/poctify-codeshare/src/components/Navbar.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import logo from '../assets/logo.svg';
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false);
+  return (
+    <nav className="bg-poctifyBlue text-white p-4 flex items-center justify-between">
+      <Link to="/" className="flex items-center space-x-2">
+        <img src={logo} alt="POCTIFY" className="h-8" />
+        <span className="font-semibold">POCTIFY</span>
+      </Link>
+      <button className="md:hidden" onClick={() => setOpen(!open)}>
+        ☰
+      </button>
+      <ul className={`md:flex space-x-4 ${open ? 'block' : 'hidden md:block'}`}>
+        <li><Link to="/" className="hover:underline">Home</Link></li>
+        <li><Link to="/dashboard" className="hover:underline">Dashboard</Link></li>
+        <li><a href="#" className="hover:underline">About</a></li>
+        <li><a href="#" className="hover:underline">Contact</a></li>
+      </ul>
+    </nav>
+  );
+}

--- a/poctify-codeshare/src/components/RecordsTable.jsx
+++ b/poctify-codeshare/src/components/RecordsTable.jsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+
+export default function RecordsTable({ rows }) {
+  const [page, setPage] = useState(0);
+  const perPage = 100;
+  const paged = rows.slice(page * perPage, (page + 1) * perPage);
+  const maxPage = Math.ceil(rows.length / perPage);
+
+  return (
+    <div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm mt-4">
+          <thead>
+            <tr>
+              <th>Timestamp</th>
+              <th>Operator</th>
+              <th>Location</th>
+              <th>Device</th>
+            </tr>
+          </thead>
+          <tbody>
+            {paged.map((r, idx) => (
+              <tr key={idx} className="bg-white text-gray-800">
+                <td>{r.timestampRaw}</td>
+                <td>{r.operator_id}</td>
+                <td>{r.location}</td>
+                <td>{r.device}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {maxPage > 1 && (
+        <div className="mt-2 space-x-2">
+          <button
+            className="px-2 py-1 bg-poctifyBlue text-white rounded disabled:opacity-50"
+            onClick={() => setPage(Math.max(0, page - 1))}
+            disabled={page === 0}
+          >
+            Prev
+          </button>
+          <button
+            className="px-2 py-1 bg-poctifyBlue text-white rounded disabled:opacity-50"
+            onClick={() => setPage(Math.min(maxPage - 1, page + 1))}
+            disabled={page >= maxPage - 1}
+          >
+            Next
+          </button>
+          <span>
+            Page {page + 1} of {maxPage}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/poctify-codeshare/src/components/SummaryPanel.jsx
+++ b/poctify-codeshare/src/components/SummaryPanel.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export default function SummaryPanel({ anomalies, totalTests }) {
+  const suspicious = anomalies.filter(a => a.totalScore > 0).length;
+  return (
+    <div className="grid grid-cols-3 gap-4 text-center">
+      <div className="p-4 bg-white text-gray-800 rounded shadow-md">
+        <p className="text-sm">Operators</p>
+        <p className="text-xl font-bold">{anomalies.length}</p>
+      </div>
+      <div className="p-4 bg-white text-gray-800 rounded shadow-md">
+        <p className="text-sm">Suspicious</p>
+        <p className="text-xl font-bold">{suspicious}</p>
+      </div>
+      <div className="p-4 bg-white text-gray-800 rounded shadow-md">
+        <p className="text-sm">Total Tests</p>
+        <p className="text-xl font-bold">{totalTests}</p>
+      </div>
+    </div>
+  );
+}

--- a/poctify-codeshare/src/components/SuspiciousTable.jsx
+++ b/poctify-codeshare/src/components/SuspiciousTable.jsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import { downloadCSV } from '../utils/exporter';
+
+export default function SuspiciousTable({ data }) {
+  const [sortKey, setSortKey] = useState('totalScore');
+  const [desc, setDesc] = useState(true);
+  const [filter, setFilter] = useState(0);
+
+  const sorted = [...data]
+    .filter(r => r.totalScore >= filter)
+    .sort((a, b) => {
+      const res = a[sortKey] > b[sortKey] ? 1 : -1;
+      return desc ? -res : res;
+    });
+
+  const toggleSort = key => {
+    if (key === sortKey) setDesc(!desc);
+    else {
+      setSortKey(key);
+      setDesc(true);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex justify-between mb-2">
+        <input
+          type="number"
+          value={filter}
+          onChange={e => setFilter(Number(e.target.value))}
+          className="text-black p-1 mr-2"
+          placeholder="Min score"
+        />
+        <button
+          className="bg-poctifyBlue px-2 py-1 rounded"
+          onClick={() => downloadCSV(sorted, 'suspicious.csv')}
+        >
+          Export CSV
+        </button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm text-left">
+          <thead className="cursor-pointer">
+            <tr>
+              <th onClick={() => toggleSort('operator_id')}>Operator ID</th>
+              <th onClick={() => toggleSort('tests')}>Tests</th>
+              <th onClick={() => toggleSort('totalScore')}>Total Score</th>
+              <th onClick={() => toggleSort('avgScore')}>Avg Score</th>
+              <th onClick={() => toggleSort('bursts')}>Bursts</th>
+              <th onClick={() => toggleSort('peakHour')}>Peak Hour</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(row => (
+              <tr
+                key={row.operator_id}
+                className={
+                  row.avgScore > 10
+                    ? 'bg-red-200 text-gray-800'
+                    : row.avgScore > 5
+                    ? 'bg-yellow-200 text-gray-800'
+                    : 'bg-green-200 text-gray-800'
+                }
+              >
+                <td>{row.operator_id}</td>
+                <td>{row.tests}</td>
+                <td>{row.totalScore}</td>
+                <td>{row.avgScore.toFixed(2)}</td>
+                <td>{row.bursts}</td>
+                <td>{row.peakHour}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/poctify-codeshare/src/components/UploadForm.jsx
+++ b/poctify-codeshare/src/components/UploadForm.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { parseFile } from '../utils/parser';
+
+export default function UploadForm({ onData }) {
+  async function handleFile(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    const rows = await parseFile(file);
+    onData(rows);
+  }
+
+  return (
+    <div className="space-y-2">
+      <input
+        type="file"
+        accept=".xlsx,.xls,.csv"
+        onChange={handleFile}
+        className="text-white"
+      />
+      <a
+        href="/template.csv"
+        className="underline text-poctifySoft"
+        download
+      >
+        Download CSV Template
+      </a>
+    </div>
+  );
+}

--- a/poctify-codeshare/src/index.css
+++ b/poctify-codeshare/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/poctify-codeshare/src/main.jsx
+++ b/poctify-codeshare/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/poctify-codeshare/src/pages/Dashboard.jsx
+++ b/poctify-codeshare/src/pages/Dashboard.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import UploadForm from '../components/UploadForm';
+import SummaryPanel from '../components/SummaryPanel';
+import SuspiciousTable from '../components/SuspiciousTable';
+import RecordsTable from '../components/RecordsTable';
+import ChartsPanel from '../components/ChartsPanel';
+import { detectAnomalies } from '../utils/anomalyDetector';
+
+export default function Dashboard() {
+  const [rows, setRows] = useState([]);
+  const [anomalies, setAnomalies] = useState([]);
+
+  function onData(data) {
+    setRows(data);
+    setAnomalies(detectAnomalies(data));
+  }
+
+  return (
+    <div className="p-6 grid grid-cols-1 gap-6" id="report-container">
+      <UploadForm onData={onData} />
+      <SummaryPanel anomalies={anomalies} totalTests={rows.length} />
+      <SuspiciousTable data={anomalies} />
+      <ChartsPanel anomalies={anomalies} />
+      <RecordsTable rows={rows} />
+    </div>
+  );
+}

--- a/poctify-codeshare/src/pages/Home.jsx
+++ b/poctify-codeshare/src/pages/Home.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export default function Home() {
+  return (
+    <div className="bg-poctifyNavy text-white min-h-screen flex flex-col">
+      <div className="flex-grow flex items-center justify-center flex-col">
+        <h1 className="text-3xl font-bold mb-2">POCTIFY CodeShare Detector</h1>
+        <p className="mb-6">Identify operator misuse using real-world POCT logs</p>
+        <Link
+          to="/dashboard"
+          className="bg-poctifyBlue hover:bg-poctifySoft text-white font-semibold py-2 px-4 rounded"
+        >
+          Launch Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/poctify-codeshare/src/utils/anomalyDetector.js
+++ b/poctify-codeshare/src/utils/anomalyDetector.js
@@ -1,0 +1,52 @@
+export function detectAnomalies(rows, config = {}) {
+  const defaults = {
+    workingHours: [7, 20],
+    wardSwitchMins: 10,
+    deviceSwitchMins: 10,
+    burstThreshold: 3,
+    burstWindow: 5,
+    hourlyLimit: 15,
+  };
+  const cfg = { ...defaults, ...config };
+
+  const byOperator = new Map();
+  rows.forEach(row => {
+    if (!byOperator.has(row.operator_id)) byOperator.set(row.operator_id, []);
+    byOperator.get(row.operator_id).push(row);
+  });
+
+  const summaries = [];
+  byOperator.forEach((events, operator_id) => {
+    let score = 0;
+    let bursts = 0;
+    const hours = {};
+    events.forEach((e, idx) => {
+      const hour = e.timestamp.getHours();
+      hours[hour] = (hours[hour] || 0) + 1;
+      if (hour < cfg.workingHours[0] || hour >= cfg.workingHours[1]) {
+        score += 2;
+      }
+      if (idx > 0) {
+        const prev = events[idx - 1];
+        const delta = (e.timestamp - prev.timestamp) / 60000;
+        if (e.location !== prev.location && delta < cfg.wardSwitchMins) score += 5;
+        if (e.device !== prev.device && delta < cfg.deviceSwitchMins) score += 2;
+      }
+      const windowStart = new Date(e.timestamp.getTime() - cfg.burstWindow * 60000);
+      const recent = events.filter(r => r.timestamp >= windowStart && r.timestamp <= e.timestamp);
+      if (recent.length >= cfg.burstThreshold) {
+        bursts += 1;
+        score += 4;
+      }
+    });
+    const totalEvents = events.length;
+    let peakHour = 0;
+    Object.values(hours).forEach(c => { if (c > peakHour) peakHour = c; });
+    if (peakHour > cfg.hourlyLimit) {
+      score += 2 * (peakHour - cfg.hourlyLimit);
+    }
+    const avgScore = score / totalEvents;
+    summaries.push({ operator_id, tests: totalEvents, totalScore: score, avgScore, bursts, peakHour, hourlyCounts: hours });
+  });
+  return summaries;
+}

--- a/poctify-codeshare/src/utils/exporter.js
+++ b/poctify-codeshare/src/utils/exporter.js
@@ -1,0 +1,21 @@
+import html2canvas from 'html2canvas';
+import jsPDF from 'jspdf';
+import { unparse } from 'papaparse';
+
+export function downloadCSV(data, filename = 'report.csv') {
+  const csv = unparse(data);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  link.click();
+}
+
+export async function downloadPDF(elementId, filename = 'report.pdf') {
+  const element = document.getElementById(elementId);
+  const canvas = await html2canvas(element);
+  const imgData = canvas.toDataURL('image/png');
+  const pdf = new jsPDF('landscape');
+  pdf.addImage(imgData, 'PNG', 10, 10, 280, 150);
+  pdf.save(filename);
+}

--- a/poctify-codeshare/src/utils/headerMatcher.js
+++ b/poctify-codeshare/src/utils/headerMatcher.js
@@ -1,0 +1,12 @@
+export function matchHeaders(rawKeys) {
+  const normalized = rawKeys.map(k => k.toLowerCase().replace(/[^a-z0-9]/g, ''));
+  const map = {};
+  ['operatorid', 'timestamp', 'location', 'device'].forEach((key) => {
+    const idx = normalized.indexOf(key);
+    if (idx === -1) {
+      throw new Error(`Missing column: ${key}`);
+    }
+    map[key] = rawKeys[idx];
+  });
+  return map;
+}

--- a/poctify-codeshare/src/utils/parser.js
+++ b/poctify-codeshare/src/utils/parser.js
@@ -1,0 +1,47 @@
+import { matchHeaders } from './headerMatcher';
+import { validateHeaders } from './validators';
+import * as XLSX from 'xlsx';
+import dayjs from 'dayjs';
+import customParse from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParse);
+
+export async function parseFile(file) {
+  const data = await file.arrayBuffer();
+  const workbook = XLSX.read(data, { type: 'array' });
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+  if (!rows.length) throw new Error('Empty file');
+  const [headerRow, ...dataRows] = rows;
+  const headerMap = matchHeaders(headerRow);
+  validateHeaders(Object.keys(headerMap));
+
+  const normalizedRows = dataRows.map(r => {
+    const obj = {};
+    Object.entries(headerMap).forEach(([key, label]) => {
+      const idx = headerRow.indexOf(label);
+      obj[key] = r[idx];
+    });
+    return obj;
+  });
+
+  const cleaned = normalizedRows.map(row => {
+    const timestampRaw = row.timestamp;
+    return {
+      operator_id: String(row.operator_id || row.operatorid).trim(),
+      timestamp: dayjs(timestampRaw, 'DD/MM/YYYY HH:mm').toDate(),
+      location: String(row.location).trim(),
+      device: String(row.device).trim(),
+      timestampRaw,
+    };
+  });
+
+  cleaned.sort((a, b) => {
+    if (a.operator_id === b.operator_id) {
+      return a.timestamp - b.timestamp;
+    }
+    return a.operator_id.localeCompare(b.operator_id);
+  });
+
+  return cleaned;
+}

--- a/poctify-codeshare/src/utils/pdfExport.js
+++ b/poctify-codeshare/src/utils/pdfExport.js
@@ -1,0 +1,12 @@
+import html2canvas from 'html2canvas';
+import jsPDF from 'jspdf';
+
+export function exportPDF(elementId) {
+  return html2canvas(document.getElementById(elementId))
+    .then(canvas => {
+      const img = canvas.toDataURL('image/png');
+      const pdf = new jsPDF('landscape');
+      pdf.addImage(img, 'PNG', 10, 10, 280, 150);
+      pdf.save('report.pdf');
+    });
+}

--- a/poctify-codeshare/src/utils/validators.js
+++ b/poctify-codeshare/src/utils/validators.js
@@ -1,0 +1,7 @@
+export function validateHeaders(keys) {
+  const required = ['operator_id', 'timestamp', 'location', 'device'];
+  const missing = required.filter(k => !keys.includes(k));
+  if (missing.length) {
+    throw new Error(`Missing column(s): ${missing.join(', ')}`);
+  }
+}

--- a/poctify-codeshare/tailwind.config.js
+++ b/poctify-codeshare/tailwind.config.js
@@ -1,0 +1,13 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {
+      colors: {
+        poctifyBlue: '#1E40AF',
+        poctifyNavy: '#0F172A',
+        poctifySoft: '#E0E7FF',
+      },
+    },
+  },
+  plugins: [],
+};

--- a/poctify-codeshare/vite.config.js
+++ b/poctify-codeshare/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: '/',
+  build: { outDir: 'dist' },
+  server: { port: 5173 },
+});


### PR DESCRIPTION
## Summary
- add router with Home and Dashboard pages
- include Navbar and Footer for layout
- implement SummaryPanel and enhanced SuspiciousTable
- provide chart rendering and paginated records
- ship template CSV and project branding assets

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68642462fa348322b829ba96c51153c6